### PR TITLE
[BugFix] Fix eaglesong demos

### DIFF
--- a/demos/eaglesong/common.py
+++ b/demos/eaglesong/common.py
@@ -29,7 +29,7 @@ class Bot:
     def create_telegram_automaton(self, context):
         routine = self.function
         if self.add_telegram_filter:
-            routine = TelegramTranslator(routine).run
+            routine = TelegramTranslator(routine)
         return Automaton(routine, context)
 
 


### PR DESCRIPTION
### Description
Fix eaglesong demos. Pass `TelegramTranslator` object instead of non existing `.run` property from the old version.

Initial exception
```
2024-03-26 09:01:05,232 - telegram.ext.Application - ERROR - No error handlers are registered, logging exception.
Traceback (most recent call last):
  File "/home/kote/anaconda3/envs/kaia/lib/python3.11/site-packages/telegram/ext/_application.py", line 1264, in process_update
    await coroutine
  File "/home/kote/anaconda3/envs/kaia/lib/python3.11/site-packages/telegram/ext/_handlers/basehandler.py", line 157, in handle_update
    return await self.callback(update, context)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/kote/PycharmProjects/kaia/kaia/eaglesong/drivers/telegram/telegram_driver.py", line 59, in run
    await self.bridge.push(self.update_type, update, context)
  File "/home/kote/PycharmProjects/kaia/kaia/eaglesong/drivers/telegram/telegram_driver.py", line 74, in push
    self.automaton_factory(context),
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/kote/PycharmProjects/kaia/demos/eaglesong/common.py", line 32, in create_telegram_automaton
    routine = TelegramTranslator(routine).run
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'TelegramTranslator' object has no attribute 'run'
```

### Screenshots
![image](https://github.com/okulovsky/kaia/assets/74787657/c81dc175-d153-4131-9f8d-763a86677a90)
![image](https://github.com/okulovsky/kaia/assets/74787657/4769fd4d-55fc-4137-be81-cac39bf68ed6)


### How it was tested
- [x] Ran the tests
- [x] Ran a couple of demos locally    

