### PR TITLE
Find Node js / npm executable for Windows (and other platforms hopefully) 

### DIFF
--- a/avatar/app/scripts/scripts_compilation.py
+++ b/avatar/app/scripts/scripts_compilation.py
@@ -1,6 +1,9 @@
 import hashlib
 import subprocess
+import shutil
+import sys
 from pathlib import Path
+from typing import Optional
 
 HASH_FILE = '.src_hash'
 
@@ -14,18 +17,50 @@ def _compute_folder_hash(folder: Path) -> str:
     return hasher.hexdigest()
 
 
+def _resolve_executable(*candidates: str) -> Optional[str]:
+    for candidate in candidates:
+        resolved = shutil.which(candidate)
+        if resolved:
+            return resolved
+    return None
+
+
 def _find_node() -> str:
-    nvm_dir = Path.home() / '.nvm' / 'versions' / 'node'
-    if nvm_dir.exists():
-        versions = sorted(nvm_dir.iterdir(), reverse=True)
-        for v in versions:
-            candidate = v / 'bin' / 'node'
-            if candidate.exists():
-                return str(candidate)
-    node = subprocess.check_output(['bash', '-ic', 'which node'], stderr=subprocess.DEVNULL, text=True).strip().splitlines()[-1]
+    if sys.platform == 'win32':
+        node = _resolve_executable('node.exe', 'node')
+    else:
+        node = _resolve_executable('node')
+        if not node:
+            nvm_dir = Path.home() / '.nvm' / 'versions' / 'node'
+            if nvm_dir.exists():
+                versions = sorted(nvm_dir.iterdir(), reverse=True)
+                for version in versions:
+                    candidate = version / 'bin' / 'node'
+                    if candidate.exists():
+                        return str(candidate)
+
     if node:
         return node
-    raise RuntimeError("node not found")
+
+    raise RuntimeError("Node.js executable was not found in PATH")
+
+
+def _find_npm(node_path: Optional[str] = None) -> str:
+    npm = _resolve_executable('npm.cmd', 'npm.exe', 'npm') if sys.platform == 'win32' else _resolve_executable('npm')
+    if npm:
+        return npm
+
+    # Fallback: npm may sit next to node but still be absent from PATH.
+    resolved_node = node_path or _find_node()
+    node_dir = Path(resolved_node).parent
+    for candidate in ('npm.cmd', 'npm.exe', 'npm'):
+        candidate_path = node_dir / candidate
+        if candidate_path.exists():
+            return str(candidate_path)
+
+    raise RuntimeError(
+        f"NPM executable was not found in PATH or near node at '{resolved_node}'"
+    )
 
 
 def compile(src_folder: Path, dst_folder: Path):
@@ -43,8 +78,9 @@ def compile(src_folder: Path, dst_folder: Path):
 
     web_root = src_folder.parent
 
+    node = _find_node()
     npm_install = subprocess.run(
-        ['npm', 'install', '--include=optional'],
+        [_find_npm(node), 'install', '--include=optional'],
         cwd=str(web_root),
         capture_output=True,
         text=True,
@@ -56,8 +92,6 @@ def compile(src_folder: Path, dst_folder: Path):
     if not vite_js.exists():
         raise RuntimeError(f"Vite not found at {vite_js} even after npm install")
 
-    node = _find_node()
-    print(f"Using node: {node}")
     result = subprocess.run(
         [node, str(vite_js), 'build', '--outDir', str(dst_folder)],
         cwd=str(web_root),


### PR DESCRIPTION
- replace bash-based node detection with shutil.which + nvm fallback
- resolve npm.cmd/npm.exe on Windows (plus sibling fallback near node)